### PR TITLE
Lock The Poetry Version To v1.1.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ linked in the index below.
 > {name}_v{version}
 
 Example:
-> setup-python_v1.2.0
+> setup-python_v1.2.1
 
 
 ### Support Policy
@@ -33,7 +33,7 @@ An index of all the currently maintained scripts, their description, and the lat
 
 | Name                           | Version | Status                        | Description                                          |
 |--------------------------------|---------|-------------------------------|------------------------------------------------------|
-| [Setup Python](./setup-python) | 1.2.0   | [![tests][sp_badge]][sp_link] | Setup a [poetry][Poetry]-managed python environment. |
+| [Setup Python](./setup-python) | 1.2.1   | [![tests][sp_badge]][sp_link] | Setup a [poetry][Poetry]-managed python environment. |
 
 
 [License]: https://shields.io/github/license/HassanAbouelela/actions

--- a/setup-python/README.md
+++ b/setup-python/README.md
@@ -8,7 +8,7 @@ It also handles caching of pre-commit if you happen to be using that.
 You can use this action as follows:
 ```yaml
 - name: Install Python Dependencies
-  uses: HassanAbouelela/actions/setup-python@setup-python_v1.2.0
+  uses: HassanAbouelela/actions/setup-python@setup-python_v1.2.1
   with:
     dev: false
     python_version: 3.9

--- a/setup-python/action.yaml
+++ b/setup-python/action.yaml
@@ -74,7 +74,7 @@ runs:
       with:
         path: ${{ env.PYTHONUSERBASE }}
         key: "python-${{ runner.os }}-${{ env.PYTHONUSERBASE }}-\
-        v1.2.0-\
+        v1.2.1-\
         ${{ steps.python_setup.outputs.python-version }}-${{ inputs.dev }}-${{ inputs.working_dir }}\
         ${{ hashFiles('./pyproject.toml', './poetry.lock') }}"
 
@@ -84,7 +84,7 @@ runs:
       with:
         path: ${{ env.PRE_COMMIT_HOME }}
         key: "precommit-${{ runner.os }}-${{ env.PRE_COMMIT_HOME }}-\
-        v1.2.0-\
+        v1.2.1-\
         ${{ steps.python_setup.outputs.python-version }}-${{ inputs.dev }}-${{ inputs.working_dir }}\
         ${{ hashFiles('./.pre-commit-config.yaml') }}"
 
@@ -103,7 +103,7 @@ runs:
         fi
 
         echo "::group::Install Poetry"
-        pip install poetry
+        pip install poetry==1.1.*
         echo "::endgroup::"
 
         echo "::group::Install Dependencies"

--- a/setup-python/tests/pyproject.toml
+++ b/setup-python/tests/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "project"
-version = "1.2.0"
+version = "1.2.1"
 description = "Simple project to test the setup-python action."
 authors = ["Hassan Abouelela <hassan@hassanamr.com>"]
 license = "MIT"


### PR DESCRIPTION
Version 1.2 of poetry introduced a regression which would error out whenever pip user installs were enabled (through the environment variable). This manifests as an error when `poetry install` is running. See #1 for an example, and a link to the poetry issue.