### PR TITLE
Remove The Environment Configuration In Favor of Using Default Caches

### DIFF
--- a/.github/workflows/test_setup_python.yaml
+++ b/.github/workflows/test_setup_python.yaml
@@ -101,6 +101,11 @@ jobs:
 
       - name: Check Cache Content
         run: |
+          if ! command -v mypy; then
+            echo "Expected mypy to be installed in the cache, was not found."
+            exit 1
+          fi
+
           if command -v black; then
             echo "Black was installed in an incorrect context."
             exit 1

--- a/.github/workflows/test_setup_python.yaml
+++ b/.github/workflows/test_setup_python.yaml
@@ -72,6 +72,7 @@ jobs:
           dev: false
           python_version: 3.9
           working_dir: setup-python/tests/
+          use_cache: false
 
   cache_hit:
     name: Test Cache Hit

--- a/.github/workflows/test_setup_python.yaml
+++ b/.github/workflows/test_setup_python.yaml
@@ -102,10 +102,7 @@ jobs:
 
       - name: Check Cache Content
         run: |
-          if ! command -v mypy; then
-            echo "Expected mypy to be installed in the cache, was not found."
-            exit 1
-          fi
+          mypy -V
 
           if command -v black; then
             echo "Black was installed in an incorrect context."

--- a/setup-python/action.yaml
+++ b/setup-python/action.yaml
@@ -41,28 +41,9 @@ runs:
     # Checkout the code to get access to project files such as poetry and pre-commit configs
     - uses: actions/checkout@v2
 
-    - name: Setup Python Settings
-      shell: bash
-      run: |
-        # Configure pip to cache dependencies and do a user install
-        echo "PIP_NO_CACHE_DIR=false" >> $GITHUB_ENV
-        echo "PIP_USER=1" >> $GITHUB_ENV
-
-        # Make sure package manager does not use virtualenv
-        echo "POETRY_VIRTUALENVS_CREATE=false" >> $GITHUB_ENV
-
-        # Specify explicit paths for python dependencies and the pre-commit
-        # environment, so we know which directories to cache
-        echo "POETRY_CACHE_DIR=${{ github.workspace }}/.cache/py-user-base" >> $GITHUB_ENV
-        echo "PRE_COMMIT_HOME=${{ github.workspace }}/.cache/pre-commit-cache" >> $GITHUB_ENV
-
-        USERBASE=${{ github.workspace }}/.cache/py-user-base
-        echo "PYTHONUSERBASE=$USERBASE" >> $GITHUB_ENV
-        echo "$USERBASE/bin" >> $GITHUB_PATH
-
     # Install python in our workflow
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       id: python_setup
       with:
         python-version: ${{ inputs.python_version }}
@@ -72,7 +53,7 @@ runs:
       uses: actions/cache@v2
       id: python_cache
       with:
-        path: ${{ env.PYTHONUSERBASE }}
+        path: ~/.cache/pypoetry
         key: "python-${{ runner.os }}-${{ env.PYTHONUSERBASE }}-\
         v1.2.1-\
         ${{ steps.python_setup.outputs.python-version }}-${{ inputs.dev }}-${{ inputs.working_dir }}\
@@ -82,7 +63,7 @@ runs:
     - name: Pre-commit Environment Caching
       uses: actions/cache@v2
       with:
-        path: ${{ env.PRE_COMMIT_HOME }}
+        path: ~/.cache/pre-commit
         key: "precommit-${{ runner.os }}-${{ env.PRE_COMMIT_HOME }}-\
         v1.2.1-\
         ${{ steps.python_setup.outputs.python-version }}-${{ inputs.dev }}-${{ inputs.working_dir }}\
@@ -103,7 +84,7 @@ runs:
         fi
 
         echo "::group::Install Poetry"
-        pip install poetry==1.1.*
+        pip install poetry
         echo "::endgroup::"
 
         echo "::group::Install Dependencies"
@@ -115,3 +96,9 @@ runs:
           poetry install ${{ inputs.install_args }} --no-dev
         fi
         echo "::endgroup::"
+
+    - name: Configure Path
+      shell: bash
+      run: |
+        cd ${{ inputs.working_dir }}
+        echo "$(poetry env info --path)/bin" >> $GITHUB_PATH

--- a/setup-python/action.yaml
+++ b/setup-python/action.yaml
@@ -71,31 +71,34 @@ runs:
         ${{ steps.python_setup.outputs.python-version }}-${{ inputs.dev }}-${{ inputs.working_dir }}\
         ${{ hashFiles('./.pre-commit-config.yaml') }}"
 
+    - name: Install Poetry
+      shell: bash
+      run: |
+        echo "::group::Install Poetry"
+        pip install poetry
+        echo "::endgroup::"
+
     - name: Install dependencies
       shell: bash
       run: |
         if [ "${{ steps.python_cache.outputs.cache-hit }}" = "true" ]; then
           if [ "${{ inputs.use_cache }}" = "false" ]; then
             echo "Caching not enbaled, deleting cache."
-            rm -rf ${{ env.PYTHONUSERBASE }}
-            rm -rf ${{ env.PRE_COMMIT_HOME }}
+            rm -rf  ~/.cache/py-user-base
+            rm -rf  ~/.cache/pre-commit
           else
             echo "Cache hit, skipping install."
             exit
           fi
         fi
 
-        echo "::group::Install Poetry"
-        pip install poetry
-        echo "::endgroup::"
-
         echo "::group::Install Dependencies"
         cd ${{ inputs.working_dir }}
 
         if [ "${{ inputs.dev }}" = "true" ]; then
-          poetry install ${{ inputs.install_args }}
+          python -m poetry install ${{ inputs.install_args }}
         else
-          poetry install ${{ inputs.install_args }} --no-dev
+          python -m poetry install ${{ inputs.install_args }} --no-dev
         fi
         echo "::endgroup::"
 
@@ -103,4 +106,4 @@ runs:
       shell: bash
       run: |
         cd ${{ inputs.working_dir }}
-        echo "$(poetry env info --path)/bin" >> $GITHUB_PATH
+        echo "$(python -m poetry env info --path)/bin" >> $GITHUB_PATH

--- a/setup-python/action.yaml
+++ b/setup-python/action.yaml
@@ -50,10 +50,12 @@ runs:
 
     # Specify directories that require caching
     - name: Python Dependency Caching
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: python_cache
       with:
-        path: ~/.cache/pypoetry
+        path: |
+          ~/.cache/pypoetry
+          ~/.cache/py-user-base
         key: "python-${{ runner.os }}-${{ env.PYTHONUSERBASE }}-\
         v1.2.1-\
         ${{ steps.python_setup.outputs.python-version }}-${{ inputs.dev }}-${{ inputs.working_dir }}\
@@ -61,7 +63,7 @@ runs:
 
     # Cache pre-commit independently of other cache
     - name: Pre-commit Environment Caching
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pre-commit
         key: "precommit-${{ runner.os }}-${{ env.PRE_COMMIT_HOME }}-\


### PR DESCRIPTION
Removes the manual management of the python configuration and
environment variables in favor of using virtualenvs, and the caching
them appropriately.

The virtualenv bin folder is added to the GITHUB_PATH to make it easily
accessible in the rest of the workflow.

This is not going to make it into a separate release, it'll be bundled with #1.