### PR TITLE
Deprecate `dev` Argument In Setup Python

### DIFF
--- a/.github/workflows/test_setup_python.yaml
+++ b/.github/workflows/test_setup_python.yaml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/test_setup_python.yaml
 
 jobs:
+  # The no_dev and dev tests are deprecated and will be removed in v2
   no_dev:
     name: Test No Developer Dependencies
     runs-on: ubuntu-latest
@@ -71,7 +72,7 @@ jobs:
       - name: Setup Python
         uses: ./setup-python
         with:
-          dev: false
+          install_args: "--without dev"
           python_version: '3.10'
           working_dir: setup-python/tests/
           use_cache: false
@@ -88,7 +89,7 @@ jobs:
         id: python
         uses: ./setup-python
         with:
-          dev: false
+          install_args: "--without dev"
           python_version: '3.10'
           working_dir: setup-python/tests/
 
@@ -145,7 +146,6 @@ jobs:
       - name: Setup Python
         uses: ./setup-python
         with:
-          dev: false
           python_version: '3.10'
           poetry_version: ${{ matrix.version }}
           working_dir: setup-python/tests/

--- a/setup-python/README.md
+++ b/setup-python/README.md
@@ -10,22 +10,22 @@ You can use this action as follows:
 - name: Install Python Dependencies
   uses: HassanAbouelela/actions/setup-python@setup-python_v1.3.3
   with:
-    dev: false
+    install_args: "--without dev"
     python_version: '3.10'
 ```
 
 ### Inputs
 The following inputs are required to use this action.
 
-| Name             | Type   | Default | Description                                                                                                                                                                   |
-|------------------|--------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| dev              | bool   | false   | Indicate whether dev dependencies should be installed. If false, the `--no-dev` flag is passed to poetry. Despite having a default, it's good practice to explicitly set one. |
-| python_version   | string |         | Specify the python version passed to the `actions/setup-python` action.                                                                                                       |
-| poetry_version   | string | poetry  | The version of poetry to install and use. This is passed directly to pip, so you can specify any pattern, such as `poetry~=1.2` or `poetry==1.1.15`.                          |
-| working_dir      | path   | `.`     | The directory to run the `poetry install` command in. By default, this will just be the root directory.                                                                       |
-| use_cache        | bool   | true    | Enable or disable the usage of cache, even if it is available.                                                                                                                |
-| cache_pre-commit | bool   | true    | Enable caching and restoring pre-commit installs. Only a pre-commit config at the root workspace will be cached properly.                                                     |
-| install_args     | string |         | A string placed after the `poetry install` command, which can contain extra options.                                                                                          |
+| Name             | Type   | Default | Description                                                                                                                                          |
+|------------------|--------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| python_version   | string |         | Specify the python version passed to the `actions/setup-python` action.                                                                              |
+| poetry_version   | string | poetry  | The version of poetry to install and use. This is passed directly to pip, so you can specify any pattern, such as `poetry~=1.2` or `poetry==1.1.15`. |
+| working_dir      | path   | `.`     | The directory to run the `poetry install` command in. By default, this will just be the root directory.                                              |
+| use_cache        | bool   | true    | Enable or disable the usage of cache, even if it is available.                                                                                       |
+| cache_pre-commit | bool   | true    | Enable caching and restoring pre-commit installs. Only a pre-commit config at the root workspace will be cached properly.                            |
+| install_args     | string |         | A string placed after the `poetry install` command, which can contain extra options.                                                                 |
+| dev (deprecated) | bool   | true    | This argument is deprecated. Please use `install_args` with the appropriate options. This option will be removed in the next major release.          |
 
 ### Outputs
 The following outputs are produced by the action:

--- a/setup-python/action.yaml
+++ b/setup-python/action.yaml
@@ -2,11 +2,6 @@ name: "Setup Python"
 description: "Setup python, install poetry, install dependencies, cache."
 
 inputs:
-  dev:
-    description: "Install developer dependencies."
-    required: true
-    default: "false"
-
   python_version:
     description: "The python version to use."
     required: true
@@ -35,6 +30,12 @@ inputs:
     description: "The poetry version to install (passed to pip install)"
     required: false
     default: "poetry"
+
+  dev:
+    description: "Install developer dependencies."
+    required: false
+    default: "true"
+    deprecationMessage: "The dev argument of the `setup-python` action is deprecated, please use `install_args` with the appropriate options. This will be removed in the next major release."
 
 outputs:
   cache-hit:
@@ -66,7 +67,7 @@ runs:
         path: |
           ~/.cache/pypoetry
           ~/.cache/py-user-base
-        key: "python-${{ runner.os }}-v1.3.3-\
+        key: "python-${{ runner.os }}-v1.3.4b1-\
         ${{ steps.python_setup.outputs.python-version }}-${{ inputs.dev }}-${{ inputs.working_dir }}-${{ inputs.poetry_version }}-${{ inputs.install_args }}-\
         ${{ hashFiles(format('{0}/pyproject.toml', inputs.working_dir), format('{0}/poetry.lock', inputs.working_dir)) }}"
 
@@ -76,7 +77,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/pre-commit
-        key: "precommit-${{ runner.os }}-v1.3.3-\
+        key: "precommit-${{ runner.os }}-v1.3.4b1-\
         ${{ steps.python_setup.outputs.python-version }}-${{ inputs.dev }}-${{ inputs.working_dir }}-${{ inputs.poetry_version }}-\
         ${{ hashFiles('./.pre-commit-config.yaml') }}"
 
@@ -104,10 +105,18 @@ runs:
         echo "::group::Install Dependencies"
         cd ${{ inputs.working_dir }}
 
-        if [ "${{ inputs.dev }}" = "true" ]; then
-          python -m poetry install ${{ inputs.install_args }}
+        if [[ "$(python -m poetry -V)" =~ .*"1.1.".* ]]; then
+          if [ "${{ inputs.dev }}" = "true" ]; then
+            python -m poetry install ${{ inputs.install_args }}
+          else
+            python -m poetry install ${{ inputs.install_args }} --no-dev
+          fi
         else
-          python -m poetry install ${{ inputs.install_args }} --no-dev
+          if [ "${{ inputs.dev }}" = "true" ]; then
+            python -m poetry install ${{ inputs.install_args }}
+          else
+            python -m poetry install ${{ inputs.install_args }} --without dev
+          fi
         fi
         echo "::endgroup::"
 


### PR DESCRIPTION
Closes #13 

Poetry v1.2 deprecated the `--no-dev` option in favor of specifying install groups. The related action option has been deprecated, and points users towards the `install_args` option instead.

To allow for smooth behavior, the default for the `dev` argument has been set to true, and argument is no longer required. This is necessary since setting `dev` false should still pass the appropriate `--no-dev` option for the specified poetry version, which would force users to set `dev` to true even when using the new format, and thus forcing the use of the deprecated option.