### PR TITLE
Bump external action versions

### DIFF
--- a/.github/workflows/test_setup_python.yaml
+++ b/.github/workflows/test_setup_python.yaml
@@ -143,8 +143,9 @@ jobs:
     strategy:
       matrix:
         version:
-          - "poetry==1.4.*"
-          - "poetry==1.5.*"
+          - "poetry==1.6.*"
+          - "poetry==1.7.*"
+          - "poetry==1.8.*"
           - "git+https://github.com/python-poetry/poetry.git@master"
 
     steps:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ linked in the index below.
 > {name}_v{version}
 
 Example:
-> setup-python_v1.4.2
+> setup-python_v1.5.0
 
 
 ### Support Policy
@@ -33,7 +33,7 @@ An index of all the currently maintained scripts, their description, and the lat
 
 | Name                           | Version | Status                        | Description                                          |
 |--------------------------------|---------|-------------------------------|------------------------------------------------------|
-| [Setup Python](./setup-python) | 1.4.2   | [![tests][sp_badge]][sp_link] | Setup a [poetry][Poetry]-managed python environment. |
+| [Setup Python](./setup-python) | 1.5.0   | [![tests][sp_badge]][sp_link] | Setup a [poetry][Poetry]-managed python environment. |
 
 
 [License]: https://shields.io/github/license/HassanAbouelela/actions

--- a/setup-python/README.md
+++ b/setup-python/README.md
@@ -8,7 +8,7 @@ It also handles caching of pre-commit if you happen to be using that.
 You can use this action as follows:
 ```yaml
 - name: Install Python Dependencies
-  uses: HassanAbouelela/actions/setup-python@setup-python_v1.4.2
+  uses: HassanAbouelela/actions/setup-python@setup-python_v1.5.0
   with:
     install_args: "--without dev"
     python_version: '3.10'

--- a/setup-python/action.yaml
+++ b/setup-python/action.yaml
@@ -60,14 +60,14 @@ runs:
 
     # Install python in our workflow
     - name: Setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       id: python_setup
       with:
         python-version: ${{ inputs.python_version }}
 
     # Specify directories that require caching
     - name: Python Dependency Caching
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: python_cache
       with:
         path: |
@@ -80,7 +80,7 @@ runs:
     # Cache pre-commit independently of other cache
     - name: Pre-commit Environment Caching
       if: ${{ inputs.cache_pre-commit }} == true
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pre-commit
         key: "precommit-${{ runner.os }}-v1.4.2-\

--- a/setup-python/action.yaml
+++ b/setup-python/action.yaml
@@ -73,7 +73,7 @@ runs:
         path: |
           ~/.cache/pypoetry
           ~/.cache/pip
-        key: "python-${{ runner.os }}-v1.4.2-\
+        key: "python-${{ runner.os }}-v1.5.0-\
         ${{ steps.python_setup.outputs.python-version }}-${{ inputs.dev }}-${{ inputs.working_dir }}-${{ inputs.poetry_version }}-${{ inputs.install_args }}-\
         ${{ hashFiles(format('{0}/pyproject.toml', inputs.working_dir), format('{0}/poetry.lock', inputs.working_dir)) }}"
 
@@ -83,7 +83,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/pre-commit
-        key: "precommit-${{ runner.os }}-v1.4.2-\
+        key: "precommit-${{ runner.os }}-v1.5.0-\
         ${{ steps.python_setup.outputs.python-version }}-${{ inputs.dev }}-${{ inputs.working_dir }}-${{ inputs.poetry_version }}-\
         ${{ hashFiles('./.pre-commit-config.yaml') }}"
 

--- a/setup-python/tests/pyproject.toml
+++ b/setup-python/tests/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "project"
-version = "1.4.2"
+version = "1.5.0"
 description = "Simple project to test the setup-python action."
 authors = ["Hassan Abouelela <hassan@hassanamr.com>"]
 license = "MIT"


### PR DESCRIPTION
This bumps setup-python and cache actions up to latest version to bump the version of node they use.

Currently as they use node 16, giuthub shows deprecation notices when this action is used.