### PR TITLE
Allow Specifying Python Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ linked in the index below.
 > {name}_v{version}
 
 Example:
-> setup-python_v1.5.0
+> setup-python_v1.6.0
 
 
 ### Support Policy
@@ -33,7 +33,7 @@ An index of all the currently maintained scripts, their description, and the lat
 
 | Name                           | Version | Status                        | Description                                          |
 |--------------------------------|---------|-------------------------------|------------------------------------------------------|
-| [Setup Python](./setup-python) | 1.5.0   | [![tests][sp_badge]][sp_link] | Setup a [poetry][Poetry]-managed python environment. |
+| [Setup Python](./setup-python) | 1.6.0   | [![tests][sp_badge]][sp_link] | Setup a [poetry][Poetry]-managed python environment. |
 
 
 [License]: https://shields.io/github/license/HassanAbouelela/actions

--- a/setup-python/README.md
+++ b/setup-python/README.md
@@ -8,14 +8,14 @@ It also handles caching of pre-commit if you happen to be using that.
 You can use this action as follows:
 ```yaml
 - name: Install Python Dependencies
-  uses: HassanAbouelela/actions/setup-python@setup-python_v1.5.0
+  uses: HassanAbouelela/actions/setup-python@setup-python_v1.6.0
   with:
     install_args: "--without dev"
     python_version: '3.10'
 ```
 
 ### Inputs
-The following inputs are required to use this action.
+The following inputs can be used to configure the action:
 
 | Name             | Type   | Default | Description                                                                                                                                          |
 |------------------|--------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -26,6 +26,7 @@ The following inputs are required to use this action.
 | cache_pre-commit | bool   | true    | Enable caching and restoring pre-commit installs. Only a pre-commit config at the root workspace will be cached properly.                            |
 | install_args     | string |         | A string placed after the `poetry install` command, which can contain extra options.                                                                 |
 | checkout         | bool   | true    | Perform a checkout of the repository in the action. If this is false, this must be done manually before running the action.                          |
+| python_cmd       | string | python  | The python command to be used. This is incompatible with `python_version`.                                                                           |
 | dev (deprecated) | bool   | true    | This argument is deprecated. Please use `install_args` with the appropriate options. This option will be removed in the next major release.          |
 
 ### Outputs

--- a/setup-python/action.yaml
+++ b/setup-python/action.yaml
@@ -105,7 +105,7 @@ runs:
         path: |
           ~/.cache/pypoetry
           ~/.cache/pip
-        key: "python-${{ runner.os }}-v1.5.0-\
+        key: "python-${{ runner.os }}-v1.6.0-\
         ${{ steps.python_ver.outputs.python-version }}-${{ inputs.dev }}-${{ inputs.working_dir }}-${{ inputs.poetry_version }}-${{ inputs.install_args }}-\
         ${{ hashFiles(format('{0}/pyproject.toml', inputs.working_dir), format('{0}/poetry.lock', inputs.working_dir)) }}"
 
@@ -115,7 +115,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/pre-commit
-        key: "precommit-${{ runner.os }}-v1.5.0-\
+        key: "precommit-${{ runner.os }}-v1.6.0-\
         ${{ steps.python_ver.outputs.python-version }}-${{ inputs.dev }}-${{ inputs.working_dir }}-${{ inputs.poetry_version }}-\
         ${{ hashFiles('./.pre-commit-config.yaml') }}"
 

--- a/setup-python/action.yaml
+++ b/setup-python/action.yaml
@@ -36,6 +36,11 @@ inputs:
     required: false
     default: "true"
 
+  python_cmd:
+    description: "The python command to be used. If not specified, it defaults to just 'python'. Incompatible with 'python_version'."
+    required: false
+    default: ""
+
   dev:
     description: "Install developer dependencies."
     required: false
@@ -48,7 +53,7 @@ outputs:
     value: ${{ steps.python_cache.outputs.cache-hit }}
   python-version:
     description: "The full Python semver version used."
-    value: ${{ steps.python_setup.outputs.python-version }}
+    value: ${{ steps.python_ver.outputs.python-version }}
 
 runs:
   using: "composite"
@@ -56,14 +61,41 @@ runs:
   steps:
     # Checkout the code to get access to project files such as poetry and pre-commit configs
     - uses: actions/checkout@v4
-      if: ${{ inputs.checkout }} == true
+      if: inputs.checkout == 'true'
 
     # Install python in our workflow
     - name: Setup python
       uses: actions/setup-python@v5
+      if: inputs.python_cmd == ''
       id: python_setup
       with:
         python-version: ${{ inputs.python_version }}
+
+    # Export the selected python version
+    - name: Select Python Runtime
+      id: python_ver
+      shell: bash
+      run: |
+        echo "::group::Select Python Runtime"
+        if [ "${{ inputs.python_cmd }}" = "" ]; then
+          # We're using a normal setup-python install, just re-export the version
+          echo "python-version=${{ steps.python_setup.outputs.python-version }}" >> "$GITHUB_OUTPUT"
+          echo "python-cmd=python" >> "$GITHUB_OUTPUT"
+        else
+          # The user is bringing their own python version. Test it and export the version.
+          py_cmd="${{ inputs.python_cmd }}"
+          echo "Using python from: $py_cmd"
+          if ! command -v "$py_cmd" &> /dev/null; then
+            echo "Could not locate python command. Make sure it is available on path?"
+            echo "Path: $PATH"
+            echo "PWD: $PWD"
+            echo "CMD: $py_cmd"
+            exit 1
+          fi
+          echo "python-version=$($py_cmd -V | cut -d " " -f 2)" >> "$GITHUB_OUTPUT"
+          echo "python-cmd=$py_cmd" >> "$GITHUB_OUTPUT"
+        fi
+        echo "::endgroup::"
 
     # Specify directories that require caching
     - name: Python Dependency Caching
@@ -74,24 +106,25 @@ runs:
           ~/.cache/pypoetry
           ~/.cache/pip
         key: "python-${{ runner.os }}-v1.5.0-\
-        ${{ steps.python_setup.outputs.python-version }}-${{ inputs.dev }}-${{ inputs.working_dir }}-${{ inputs.poetry_version }}-${{ inputs.install_args }}-\
+        ${{ steps.python_ver.outputs.python-version }}-${{ inputs.dev }}-${{ inputs.working_dir }}-${{ inputs.poetry_version }}-${{ inputs.install_args }}-\
         ${{ hashFiles(format('{0}/pyproject.toml', inputs.working_dir), format('{0}/poetry.lock', inputs.working_dir)) }}"
 
     # Cache pre-commit independently of other cache
     - name: Pre-commit Environment Caching
-      if: ${{ inputs.cache_pre-commit }} == true
+      if: inputs.cache_pre-commit == 'true'
       uses: actions/cache@v4
       with:
         path: ~/.cache/pre-commit
         key: "precommit-${{ runner.os }}-v1.5.0-\
-        ${{ steps.python_setup.outputs.python-version }}-${{ inputs.dev }}-${{ inputs.working_dir }}-${{ inputs.poetry_version }}-\
+        ${{ steps.python_ver.outputs.python-version }}-${{ inputs.dev }}-${{ inputs.working_dir }}-${{ inputs.poetry_version }}-\
         ${{ hashFiles('./.pre-commit-config.yaml') }}"
 
     - name: Install Poetry
       shell: bash
       run: |
         echo "::group::Install Poetry"
-        pip install ${{ inputs.poetry_version }}
+        echo "Installing poetry under python version ${{ steps.python_ver.outputs.python-version }}"
+        ${{ steps.python_ver.outputs.python-cmd }} -m pip install ${{ inputs.poetry_version }}
         echo "::endgroup::"
 
     - name: Install dependencies
@@ -111,18 +144,19 @@ runs:
 
         echo "::group::Install Dependencies"
         cd ${{ inputs.working_dir }}
+        py_cmd="${{ steps.python_ver.outputs.python-cmd }}"
 
-        if [[ "$(python -m poetry -V)" =~ .*"1.1.".* ]]; then
+        if [[ "$($py_cmd -m poetry -V)" =~ .*"1.1.".* ]]; then
           if [ "${{ inputs.dev }}" = "true" ]; then
-            python -m poetry install ${{ inputs.install_args }}
+            $py_cmd -m poetry install ${{ inputs.install_args }}
           else
-            python -m poetry install ${{ inputs.install_args }} --no-dev
+            $py_cmd -m poetry install ${{ inputs.install_args }} --no-dev
           fi
         else
           if [ "${{ inputs.dev }}" = "true" ]; then
-            python -m poetry install ${{ inputs.install_args }}
+            $py_cmd -m poetry install ${{ inputs.install_args }}
           else
-            python -m poetry install ${{ inputs.install_args }} --without dev
+            $py_cmd -m poetry install ${{ inputs.install_args }} --without dev
           fi
         fi
         echo "::endgroup::"
@@ -132,7 +166,8 @@ runs:
       run: |
         echo "::group::Configure Path"
         cd ${{ inputs.working_dir }}
-        echo "$(python -m poetry env info --path)/bin" >> $GITHUB_PATH
-        echo "Added $(python -m poetry env info --path)/bin to path"
-        python -m poetry -V
+        py_cmd="${{ steps.python_ver.outputs.python-cmd }}"
+        echo "$($py_cmd -m poetry env info --path)/bin" >> $GITHUB_PATH
+        echo "Added $($py_cmd -m poetry env info --path)/bin to path"
+        $py_cmd -m poetry -V
         echo "::endgroup::"

--- a/setup-python/tests/pyproject.toml
+++ b/setup-python/tests/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "project"
-version = "1.5.0"
+version = "1.6.0"
 description = "Simple project to test the setup-python action."
 authors = ["Hassan Abouelela <hassan@hassanamr.com>"]
 license = "MIT"


### PR DESCRIPTION
Allow users to specify a custom path for the python command, bypassing the traditional `actions/setup-python` action. This can be useful where custom built python environments are required, or where the normal setup does not support the runner.